### PR TITLE
make updated DataHandler thread-safe again

### DIFF
--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
@@ -116,8 +116,7 @@ namespace Edia.Eye {
         /// to detect an intersection with colliders in the scene, and populates the eye data package with the intersection details if a hit occurs.
         /// </summary>
         /// <param name="latestSample">The eye data package containing the initial local-space gaze data.</param>
-        /// <returns>The updated eye data package containing intersection details if a hit is detected, or the original data if no hit occurs.</returns>
-        private EyeDataPackage RegisterIntersection(EyeDataPackage latestSample) {
+        private void RegisterIntersection(EyeDataPackage latestSample) {
             
             Vector3 pos = transform.TransformPoint(new Vector3(
                     latestSample.position_x_local, 
@@ -144,8 +143,6 @@ namespace Edia.Eye {
             else {
                 if (ShowDebugRay) { Debug.DrawRay(pos, dir * _rayDistance, Color.red); }
             }
-
-            return latestSample;
         }
     }
 }

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
@@ -79,6 +79,13 @@ namespace Edia.Eye {
                 if (_currentSamples.Count == 0)
                     continue;
 
+                // To detect intersections we need the current pose. Note that this assumes the same pose (the one valid
+                // at the end of the frame) for all ET samples collected during the frame. In practice, this should not
+                // make a relevant difference for hit detection. 
+                foreach (var sample in _currentSamples) {
+                    RegisterIntersection(sample);
+                }
+                
                 lock (Lock) {
                     // Push listed samples to all clients
                     foreach (IEyeDataClient dataClient in _dataClients) {
@@ -100,7 +107,7 @@ namespace Edia.Eye {
         /// </summary>
         /// <param name="latestSample">The latest eye-tracking sample to be added to the list.</param>
         public void AddEyeDataPackage(EyeDataPackage latestSample) {
-            _currentSamples.Add(RegisterIntersection(latestSample));
+            _currentSamples.Add(latestSample);
         }
 
         /// <summary>
@@ -112,7 +119,7 @@ namespace Edia.Eye {
         /// <returns>The updated eye data package containing intersection details if a hit is detected, or the original data if no hit occurs.</returns>
         private EyeDataPackage RegisterIntersection(EyeDataPackage latestSample) {
             
-            Vector3 Pos = transform.TransformPoint(new Vector3(
+            Vector3 pos = transform.TransformPoint(new Vector3(
                     latestSample.position_x_local, 
                     latestSample.position_y_local, 
                     latestSample.position_z_local)
@@ -126,16 +133,16 @@ namespace Edia.Eye {
 
             RaycastHit hit;
 
-            if (Physics.Raycast(Pos, dir, out hit, 50, _gazeLayer)) {
+            if (Physics.Raycast(pos, dir, out hit, 50, _gazeLayer)) {
                 latestSample.target_id      = hit.collider.name;
                 latestSample.intersection_x = hit.point.x;
                 latestSample.intersection_y = hit.point.y;
                 latestSample.intersection_z = hit.point.z;
 
-                if (ShowDebugRay) { Debug.DrawRay(Pos, dir * hit.distance, Color.green); }
+                if (ShowDebugRay) { Debug.DrawRay(pos, dir * hit.distance, Color.green); }
             }
             else {
-                if (ShowDebugRay) { Debug.DrawRay(Pos, dir * _rayDistance, Color.red); }
+                if (ShowDebugRay) { Debug.DrawRay(pos, dir * _rayDistance, Color.red); }
             }
 
             return latestSample;

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
@@ -78,15 +78,15 @@ namespace Edia.Eye {
 
                 if (_currentSamples.Count == 0)
                     continue;
-
-                // To detect intersections we need the current pose. Note that this assumes the same pose (the one valid
-                // at the end of the frame) for all ET samples collected during the frame. In practice, this should not
-                // make a relevant difference for hit detection. 
-                foreach (var sample in _currentSamples) {
-                    RegisterIntersection(sample);
-                }
                 
                 lock (Lock) {
+                    // To detect intersections we need the current pose. Note that this assumes the same pose (the one valid
+                    // at the end of the frame) for all ET samples collected during the frame. In practice, this should not
+                    // make a relevant difference for hit detection. 
+                    for (int i = 0; i < _currentSamples.Count; i++) {
+                        RegisterIntersection(_currentSamples[i]);
+                    }
+                    
                     // Push listed samples to all clients
                     foreach (IEyeDataClient dataClient in _dataClients) {
                         dataClient.ProcessCurrentSamples(_currentSamples);

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
@@ -83,7 +83,7 @@ namespace Edia.Eye {
                     // To detect intersections we need the current pose. Note that this assumes the same pose (the one valid
                     // at the end of the frame) for all ET samples collected during the frame. In practice, this should not
                     // make a relevant difference for hit detection. 
-                    // Note that we CANNOT use `foreach` (which makes a copy of the list) here, bc we ae updating the
+                    // Note that we CANNOT use `foreach` (which makes a copy of the list) here, bc we are updating the
                     // samples in-place.
                     for (int i = 0; i < _currentSamples.Count; i++) {
                         RegisterIntersection(_currentSamples[i]);
@@ -113,7 +113,7 @@ namespace Edia.Eye {
         }
 
         /// <summary>
-        /// Updates (in place!) the given eye data package with intersection data resulting from a raycast operation.
+        /// Updates (in-place!) the given eye data package with intersection data resulting from a raycast operation.
         /// This method computes the world-space position and direction of the eye's gaze, performs a raycast
         /// to detect an intersection with colliders in the scene, and populates the eye data package with the intersection details if a hit occurs.
         /// </summary>

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
@@ -83,6 +83,8 @@ namespace Edia.Eye {
                     // To detect intersections we need the current pose. Note that this assumes the same pose (the one valid
                     // at the end of the frame) for all ET samples collected during the frame. In practice, this should not
                     // make a relevant difference for hit detection. 
+                    // Note that we CANNOT use `foreach` (which makes a copy of the list) here, bc we ae updating the
+                    // samples in-place.
                     for (int i = 0; i < _currentSamples.Count; i++) {
                         RegisterIntersection(_currentSamples[i]);
                     }
@@ -111,7 +113,7 @@ namespace Edia.Eye {
         }
 
         /// <summary>
-        /// Updates the given eye data package with intersection data resulting from a raycast operation.
+        /// Updates (in place!) the given eye data package with intersection data resulting from a raycast operation.
         /// This method computes the world-space position and direction of the eye's gaze, performs a raycast
         /// to detect an intersection with colliders in the scene, and populates the eye data package with the intersection details if a hit occurs.
         /// </summary>

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
@@ -115,7 +115,7 @@ namespace Edia.Eye {
         /// <summary>
         /// Updates (in-place!) the given eye data package with intersection data resulting from a raycast operation.
         /// This method computes the world-space position and direction of the eye's gaze, performs a raycast
-        /// to detect an intersection with colliders in the scene, and populates the eye data package with the intersection details if a hit occurs.
+        /// to detect an intersection with colliders (on the `_gazeLayer`) in the scene, and populates the eye data package with the intersection details if a hit occurs.
         /// </summary>
         /// <param name="latestSample">The eye data package containing the initial local-space gaze data.</param>
         private void RegisterIntersection(EyeDataPackage latestSample) {

--- a/CITATION.md
+++ b/CITATION.md
@@ -1,0 +1,1 @@
+If you are using this repository for your research or other public work, please cite the [EDIA Toolbox](https://github.com/edia-toolbox/edia_core/).


### PR DESCRIPTION
### Problem: 
After latest updates, `DataHandler` would fail on HTC Vive which calls `AddSamples()` from a separate thread. This was now using the transform of the XRCam, to calculate the intersection of the gaze ray with the world. -> only possible from main thread.

### Fix: 
calculate the intersection for each sample only at the very end of the frame (and in a locked state) using the latest pose of the XRCam in that frame. 