### PR TITLE
Feat/uxf log intersection coords

### DIFF
--- a/Assets/com.edia.eye/Runtime/Resources/Prefabs/Data/Eye-UxfTracker.prefab
+++ b/Assets/com.edia.eye/Runtime/Resources/Prefabs/Data/Eye-UxfTracker.prefab
@@ -47,7 +47,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   objectName: '[_eye_]_uxf_tracker'
   updateType: 0
-  EyeDataHandler: {fileID: 0}
   Eye: 2
 --- !u!114 &6344747835639068515
 MonoBehaviour:

--- a/Assets/com.edia.eye/Runtime/Resources/Prefabs/Data/Eye-UxfTracker.prefab
+++ b/Assets/com.edia.eye/Runtime/Resources/Prefabs/Data/Eye-UxfTracker.prefab
@@ -60,11 +60,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 34e3dacc4599bc547af4a43b0b848c66, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Note: '1. Add, if not there, the prefab: Eye-DataHandler
-
-    2. Reference the
-    prefab in the ''Eye Data Handler` slot.
+  Note: 'Add, if not there, the prefab: Eye-DataHandler
 
 
-    Note: `Object_name'' value is overwritten
-    at runtime'
+    Note: `Object_name''
+    is overwritten at runtime and can be ignored here.'

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataClientUXFTracker.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataClientUXFTracker.cs
@@ -35,7 +35,10 @@ namespace Edia.Eye {
             "confidence",
             "openness",
             "eye",
-            "target_id"
+            "target_id",
+            "intersection_x",
+            "intersection_y",
+            "intersection_z"
         };
 
         private List<EyeDataPackage> receivedEyeDataSamples = new List<EyeDataPackage>();

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataClientUXFTracker.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataClientUXFTracker.cs
@@ -107,7 +107,7 @@ namespace Edia.Eye {
 #endregion // -------------------------------------------------------------------------------------------------------------------------------
 #region TRACKER
 
-        public override string              MeasurementDescriptor => $"-eye-tracking";
+        public override string              MeasurementDescriptor => $"eye_tracking";
         public override IEnumerable<string> CustomHeader          => Properties2Log;
 
         protected override UXFDataRow GetCurrentValues() {

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataHandler.cs
@@ -134,7 +134,7 @@ namespace Edia.Eye {
 
             RaycastHit hit;
 
-            if (Physics.Raycast(pos, dir, out hit, 50, _gazeLayer)) {
+            if (Physics.Raycast(pos, dir, out hit, Mathf.Infinity, _gazeLayer)) {
                 latestSample.target_id      = hit.collider.name;
                 latestSample.intersection_x = hit.point.x;
                 latestSample.intersection_y = hit.point.y;


### PR DESCRIPTION
1. add logging of the gaze hit point in world coords to the UXF Tracker. 

2. remove the restriction that gaze hit points need to be within 50m. It's infinity now. 

3. fix naming of the eye tracking files to be coherent with other trackers. 

4.  also closes #25 