### PR TITLE
add a data converter using hmd orientation as et proxy

### DIFF
--- a/Assets/com.edia.eye/Editor/EdiaPrefabsMenu.cs
+++ b/Assets/com.edia.eye/Editor/EdiaPrefabsMenu.cs
@@ -47,16 +47,6 @@ namespace com.edia.eye.Editor {
             InstantiatePrefab("Helpers", "Eye-AvatarWithEyeBalls", menuCommand);
         }
 
-        [MenuItem("GameObject/EDIA/Eye/Helpers/Eye-DummyDataGenerator_AllEyes", false, 1)]
-        private static void CreatePrefabEyeDummyDataGeneratorAllEyes(MenuCommand menuCommand) {
-            InstantiatePrefab("Helpers", "Eye-DummyDataGenerator_AllEyes", menuCommand);
-        }
-
-        [MenuItem("GameObject/EDIA/Eye/Helpers/Eye-DummyDataGenerator_CenterEye", false, 1)]
-        private static void CreatePrefabEyeDummyDataGeneratorCenterEye(MenuCommand menuCommand) {
-            InstantiatePrefab("Helpers", "Eye-DummyDataGenerator_CenterEye", menuCommand);
-        }
-
         [MenuItem("GameObject/EDIA/Eye/Helpers/Eye-GazeIntersectionVisualizer", false, 1)]
         private static void CreatePrefabEyeGazeIntersectionVisualizer(MenuCommand menuCommand) {
             InstantiatePrefab("Helpers", "Eye-GazeIntersectionVisualizer", menuCommand);
@@ -65,6 +55,21 @@ namespace com.edia.eye.Editor {
         [MenuItem("GameObject/EDIA/Eye/Helpers/Eye-GazeVisualizer", false, 1)]
         private static void CreatePrefabEyeGazeVisualizer(MenuCommand menuCommand) {
             InstantiatePrefab("Helpers", "Eye-GazeVisualizer", menuCommand);
+        }
+        
+        [MenuItem("GameObject/EDIA/Eye/Helpers/Eye-HeadDataConverter", false, 1)]
+        private static void CreatePrefabHeadEyeDataConverter(MenuCommand menuCommand) {
+            InstantiatePrefab("Helpers", "Eye-Head-EyeDataConverter", menuCommand);
+        }
+        
+        [MenuItem("GameObject/EDIA/Eye/Helpers/Eye-DummyDataGenerator_AllEyes", false, 1)]
+        private static void CreatePrefabEyeDummyDataGeneratorAllEyes(MenuCommand menuCommand) {
+            InstantiatePrefab("Helpers", "Eye-DummyDataGenerator_AllEyes", menuCommand);
+        }
+
+        [MenuItem("GameObject/EDIA/Eye/Helpers/Eye-DummyDataGenerator_CenterEye", false, 1)]
+        private static void CreatePrefabEyeDummyDataGeneratorCenterEye(MenuCommand menuCommand) {
+            InstantiatePrefab("Helpers", "Eye-DummyDataGenerator_CenterEye", menuCommand);
         }
 
 #endregion

--- a/Assets/com.edia.eye/Runtime/Resources/Prefabs/Helpers/Eye-Head-EyeDataConverter.prefab
+++ b/Assets/com.edia.eye/Runtime/Resources/Prefabs/Helpers/Eye-Head-EyeDataConverter.prefab
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1275800005743322164
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5044410757843055877}
+  - component: {fileID: 3391058084582690957}
+  m_Layer: 0
+  m_Name: Eye-Head-EyeDataConverter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5044410757843055877
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275800005743322164}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3391058084582690957
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275800005743322164}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f6a8ea56685ae449abcbf8037d2977f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IsRunning: 1
+  UseLslTiming: 0

--- a/Assets/com.edia.eye/Runtime/Resources/Prefabs/Helpers/Eye-Head-EyeDataConverter.prefab.meta
+++ b/Assets/com.edia.eye/Runtime/Resources/Prefabs/Helpers/Eye-Head-EyeDataConverter.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 002b16ceaf4993d4f8d575bb94b79e1e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataConverterHead.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataConverterHead.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+
+namespace Edia.Eye {
+    /// <summary> Dummy class to fake a minimal data stream from an eye tracker (with 90Hz). </summary>
+    [EdiaHeader("EDIA EYE", "Proxy center eye gaze", "Generates center eye data based on headset orientation (NO REAL EYE TRACKING DATA!).")]
+    public class EyeDataConverterHead : MonoBehaviour {
+
+        [Header("Refs")]
+        public bool IsRunning = true;
+
+        public static ILslTimeAccessible LslTimer;
+        public        bool               UseLslTiming = false;
+
+        // Locals
+        private double         _timestampLsl;
+        private EyeDataPackage _ed = new();
+        private double         _lastTime;
+
+        /// <summary> Start the dummy data provider from script </summary>
+        public void StartAddingDummyEyedata() {
+            IsRunning = true;
+        }
+
+        private void Start() {
+            if (UseLslTiming) {
+                // check if the LslTiming component is available
+                if (GetComponent<ILslTimeAccessible>() == null) {
+                    Debug.LogError("To use LSL timing, the DebugDataSender requires a component on the same GameObject " +
+                                   "which implements the ILslTimeAccessible interface (e.g., Edia.Lsl.LslTiming or " +
+                                   "Edia.Lsl.EyeOutlet).");
+                }
+                else {
+                    LslTimer = GetComponent<ILslTimeAccessible>();
+                }
+            }
+        }
+
+        // Sends "looking straight ahead" (relative to head) data to the `EyeDataHandler` 
+        private void Update() {
+            if (!IsRunning)
+                return;
+
+            _ed.eye              = nameof(Constants.EyeId.CENTER).ToLower();
+            _ed.position_x_local = 0f;
+            _ed.position_y_local = 0f;
+            _ed.position_z_local = 0f;
+            _ed.diameter         = 0f;
+            _ed.rotation_x_local = 0f;
+            _ed.rotation_y_local = 0f;
+            _ed.rotation_z_local = 0f;
+            _ed.direction_x_local = 0f;
+            _ed.direction_y_local = 0f;
+            _ed.direction_z_local = 1f;
+            _ed.openness          = 0f;
+            _ed.isValid           = true;
+
+            _ed.timestamp_et = Time.realtimeSinceStartup;
+
+            _timestampLsl     = LslTimer != null ? LslTimer.GetLslTime() : 0;
+            _ed.timestamp_lsl = _timestampLsl;
+
+            EyeDataHandler.Instance.AddEyeDataPackage(_ed);
+        }
+    }
+}

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataConverterHead.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataConverterHead.cs
@@ -13,7 +13,7 @@ namespace Edia.Eye {
 
         // Locals
         private double         _timestampLsl;
-        private EyeDataPackage _ed = new();
+        private EyeDataPackage _ed;
         private double         _lastTime;
 
         /// <summary> Start the dummy data provider from script </summary>
@@ -40,6 +40,8 @@ namespace Edia.Eye {
             if (!IsRunning)
                 return;
 
+            _ed = new();
+            
             _ed.eye              = nameof(Constants.EyeId.CENTER).ToLower();
             _ed.position_x_local = 0f;
             _ed.position_y_local = 0f;

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataConverterHead.cs.meta
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataConverterHead.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f6a8ea56685ae449abcbf8037d2977f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 5a549d322ccd7c947aed2f465d6d46cd, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataGeneratorAllEyes.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataGeneratorAllEyes.cs
@@ -16,7 +16,7 @@ namespace Edia.Eye {
 
         // Locals
         private double         _timestampLsl;
-        private EyeDataPackage _ed              = new();
+        private EyeDataPackage _ed;
         private double         _randomWaitValue = 0.15f;
         private double         _lastTime;
 
@@ -43,6 +43,8 @@ namespace Edia.Eye {
         private void Update() {
             if (!IsRunning)
                 return;
+
+            _ed = new();
 
             if (Time.time > (_lastTime + _randomWaitValue)) {
                 // Update fake eye data only after random interval

--- a/Assets/com.edia.eye/Runtime/Scripts/EyeDataGeneratorCenterEye.cs
+++ b/Assets/com.edia.eye/Runtime/Scripts/EyeDataGeneratorCenterEye.cs
@@ -13,7 +13,7 @@ namespace Edia.Eye {
 
         // Locals
         private double         _timestampLsl;
-        private EyeDataPackage _ed = new();
+        private EyeDataPackage _ed;
         private double         _lastTime;
 
         /// <summary> Start the dummy data provider from script </summary>
@@ -40,6 +40,8 @@ namespace Edia.Eye {
             if (!IsRunning)
                 return;
 
+            _ed = new();
+            
             _ed.eye              = nameof(Constants.EyeId.CENTER).ToLower();
             _ed.position_x_local = 0f;
             _ed.position_y_local = 0f;


### PR DESCRIPTION
simple script and prefab which mimics a EyeData converter but just gives the "unicorn" ray / eye data.  
Main use case is for demonstrating the setup without needing a specific HMD eye submodule. Prefab and script naming are coherent with how the stuff is named in the submodules to make it clear where the actual stuff should go, etc. 
